### PR TITLE
Fix numeric string handling in schema validation

### DIFF
--- a/a8_validate/schema_validator.py
+++ b/a8_validate/schema_validator.py
@@ -153,12 +153,18 @@ def validate_preset(preset_data, path=()):
                 # Validate preset parameter
                 if param not in PRESET_SCHEMA:
                     raise InvalidParameterError(f"Invalid preset parameter: {param}", path=path + (preset_key, param))
-                
+
                 # Special case: convert Name to string if not already
                 if param == "Name" and not isinstance(value, str):
                     value = str(value)
-                
-                _validate_parameter_value(param, value, PRESET_SCHEMA[param], context=f"{preset_key}", path=path + (preset_key, param))
+
+                preset_value[param] = _validate_parameter_value(
+                    param,
+                    value,
+                    PRESET_SCHEMA[param],
+                    context=f"{preset_key}",
+                    path=path + (preset_key, param),
+                )
         
         # Check for required parameters
         for param, schema in PRESET_SCHEMA.items():
@@ -189,7 +195,13 @@ def validate_channel(channel_data, channel_number, path=()):
             if param not in CHANNEL_SCHEMA:
                 raise InvalidParameterError(f"Invalid channel parameter: {param} in Channel {channel_number}", path=path + (param,))
             
-            _validate_parameter_value(param, value, CHANNEL_SCHEMA[param], context=f"Channel {channel_number}", path=path + (param,))
+            channel_data[param] = _validate_parameter_value(
+                param,
+                value,
+                CHANNEL_SCHEMA[param],
+                context=f"Channel {channel_number}",
+                path=path + (param,),
+            )
 
     # Enforce zone count and order
     zone_keys = [k for k in channel_data.keys() if k.startswith('Zone ')]
@@ -227,8 +239,12 @@ def validate_zone(zone_data, channel_number, zone_number, path=()):
                 path=path + (param,)
             )
         
-        _validate_parameter_value(
-            param, value, ZONE_SCHEMA[param], f"Channel {channel_number}, Zone {zone_number}", path=path + (param,)
+        zone_data[param] = _validate_parameter_value(
+            param,
+            value,
+            ZONE_SCHEMA[param],
+            f"Channel {channel_number}, Zone {zone_number}",
+            path=path + (param,),
         )
     
     # Check for required parameters
@@ -392,16 +408,18 @@ def _validate_parameter_value(param, value, schema, context="", path=()):
     
     elif param_type == 'pm_source':
         if isinstance(value, int) and 1 <= value <= 8:
-            return
+            return value
         
         if isinstance(value, str):
             if value in ['Sample Input Left', 'Sample Input Right']:
-                return
+                return value
             if value.isdigit() and 1 <= int(value) <= 8:
-                return
+                return int(value)
         
         raise InvalidValueError(
             f"Parameter {param}{context_str} must be a channel number (1-8) "
             f"or 'Sample Input Left/Right', got {value}",
             path=path
         )
+
+    return value

--- a/a8_validate/tests/test_cross_reference_validator.py
+++ b/a8_validate/tests/test_cross_reference_validator.py
@@ -11,6 +11,7 @@ from a8_validate.cross_reference_validator import (
     ZoneVoltageRangeError,
     CVInputReferenceError,
 )
+from a8_validate.schema_validator import validate_preset
 
 
 class TestCrossReferenceValidator:
@@ -290,6 +291,26 @@ class TestCrossReferenceValidator:
         assert "SampleStart" in str(exc_info.value)
         assert "SampleEnd" in str(exc_info.value)
         assert "greater than" in str(exc_info.value).lower() or "after" in str(exc_info.value).lower()
+
+    def test_sample_start_end_as_strings(self):
+        """Ensure numeric strings are properly validated for sample boundaries."""
+        preset_with_string_values = {
+            "Preset 1": {
+                "Name": "Test Preset",
+                "Channel 1": {
+                    "Pitch": 0.00,
+                    "SampleStart": "1000",
+                    "SampleEnd": "500",
+                    "Zone 1": {"Sample": "test.wav"},
+                },
+            }
+        }
+
+        # validate_preset converts numbers but previously didn't propagate them
+        validate_preset(preset_with_string_values)
+
+        with pytest.raises(CrossReferenceError):
+            validate_relationships(preset_with_string_values)
 
     def test_crossfade_group_membership(self):
         """Test validation of crossfade group configuration."""


### PR DESCRIPTION
## Summary
- propagate numeric conversion in schema validation
- return converted values from `_validate_parameter_value`
- update tests for cross-reference validator to cover numeric-string sample positions
- fix regression in preset validation loop

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415fde13a88327a3a41928f975c2ef